### PR TITLE
Remove Explore section and ensure tags have full height available

### DIFF
--- a/themes/mediumish-gohugo-theme/layouts/partials/_shared/jumbotron.html
+++ b/themes/mediumish-gohugo-theme/layouts/partials/_shared/jumbotron.html
@@ -2,12 +2,7 @@
 ================================================== -->
 <div class="jumbotron fortags">
 	<div class="d-md-flex h-100">
-		<div class="col-md-4 transpdark align-self-center text-center h-100">
-			<div class="d-md-flex align-items-center justify-content-center h-100">
-				<h2 class="d-md-block d-none align-self-center py-1 font-weight-light">Explore <span class="d-none d-md-inline">→</span></h2>
-			</div>
-		</div>
-		<div class="col-md-8 p-5 align-self-center text-center">
+		<div class="col-md-12 p-5 align-self-center text-center">
 			{{ range $name, $taxonomy := .Site.Taxonomies.tags }}
 			{{ $count := len $taxonomy.Pages }}
 			<a class="mt-1 mb-1" href="{{ "/tags/" | relLangURL }}{{ $name | urlize }}">{{ $name }} ({{ $count }})</a>

--- a/themes/mediumish-gohugo-theme/static/css/medium.css
+++ b/themes/mediumish-gohugo-theme/static/css/medium.css
@@ -767,7 +767,6 @@ iframe {
         margin-bottom: -50px;
         margin-top: 3rem;
         padding: 0;
-        height: 350px;
         border-radius: 0;
         background-image: url(../images/jumbotron.jpg);
         background-size: cover;


### PR DESCRIPTION
This is how I'm seeing the tags right now:
<img width="1347" alt="Screenshot 2020-01-01 at 20 47 35" src="https://user-images.githubusercontent.com/524681/71645977-fea46980-2cd7-11ea-8286-51ca7c3a1d93.png">

The height of the tags was completely restricted, and the "Explore" part seemed a little unnecessary, so I've tried to tidy them up a little and simplify, and now it looks like this:
<img width="1630" alt="Screenshot 2020-01-01 at 20 47 29" src="https://user-images.githubusercontent.com/524681/71645990-1da2fb80-2cd8-11ea-83de-b422b0e9e82a.png">

Open to interpretation of course, but just a suggestion :)